### PR TITLE
Add save logic to the schedule create endpoint

### DIFF
--- a/src/main/php/Tapalava/Http/RequestParser.php
+++ b/src/main/php/Tapalava/Http/RequestParser.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tapalava\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Extracts information out of various formats of HTTP Requests.
+ *
+ * @author Maxwell Vandervelde <Max@MaxVandervelde.com>
+ */
+class RequestParser
+{
+    /**
+     * Get an entity array out of a POST request.
+     *
+     * This supports HTML form posts as well as JSON content entities.
+     *
+     * The data to be extracted from the request must be keyed in the request.
+     * For example, to extract the 'widget' entity from a request, the JSON
+     * content posted must be structured like this:
+     *
+     *     {
+     *         "widget": {
+     *             "foo": "bar",
+     *             "baz": "qux"
+     *         }
+     *     }
+     *
+     * Or if it's a form-encoded request, the structure should look like
+     *
+     *     schedule[foo]: bar
+     *     schedule[baz]: qux
+     *
+     * etc.
+     * Both will result in the same output of:
+     *
+     *     [
+     *         'foo' => 'bar',
+     *         'baz' => 'qux'
+     *     ]
+     *
+     * @param Request $request A POST request containing user-data to be extracted.
+     * @param string $entity The data entity to be extracted from the request.
+     * @throws BadRequestHttpException If the Request contains invalid or missing data.
+     * @return array Key/value data of the entity posted by the user.
+     */
+    public function getEntityFromPost(Request $request, $entity)
+    {
+        $format = $request->getRequestFormat('html');
+
+        switch ($format) {
+            case 'json':
+                return $this->fromJson($request, $entity);
+            case 'html':
+                return $this->fromHtml($request, $entity);
+        }
+
+        throw new BadRequestHttpException('Invalid format requested: ' . $format);
+    }
+
+    /**
+     * Get HTTP form entities from an HTTP Request.
+     *
+     * @param Request $request A POST request containing user-data to be extracted.
+     * @param string $entity The data entity to be extracted from the request.
+     * @return array Key/value data of the entity posted by the user.
+     */
+    private function fromHtml(Request $request, $entity)
+    {
+        $data = $request->get($entity);
+
+        if (null === $data) {
+            throw new BadRequestHttpException('Missing required form entity: ' . $entity);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Deserialize JSON entities from posted data.
+     *
+     * @param Request $request A POST request containing user-data to be extracted.
+     * @param string $entity The data entity to be extracted from the request.
+     * @return array Key/value data of the entity posted by the user.
+     */
+    private function fromJson(Request $request, $entity)
+    {
+        $content = $request->getContent();
+        $json = json_decode($content, true);
+
+        if (null === $json) {
+            throw new BadRequestHttpException('JSON value could not be parsed from content');
+        }
+
+        if (false === isset($json[$entity])) {
+            throw new BadRequestHttpException('missing JSON entity: ' . $entity);
+        }
+
+        return $json[$entity];
+    }
+}

--- a/src/main/php/Tapalava/Schedule/CassandraScheduleRepository.php
+++ b/src/main/php/Tapalava/Schedule/CassandraScheduleRepository.php
@@ -80,7 +80,9 @@ class CassandraScheduleRepository implements ScheduleRepository
         $id = $schedule->getId() ?: (new Uuid())->uuid();
         $days = $this->dateCollectionTransformer->toCollection($schedule->getDays());
         $tags = new Collection(Cassandra::TYPE_VARCHAR);
-        $tags->add(...$schedule->getTags());
+        if (0 !== count($schedule->getTags())) {
+            $tags->add(...$schedule->getTags());
+        }
 
         $statement = new SimpleStatement('
             INSERT INTO schedule (

--- a/src/main/php/Tapalava/Schedule/FakeScheduleRepository.php
+++ b/src/main/php/Tapalava/Schedule/FakeScheduleRepository.php
@@ -39,5 +39,8 @@ class FakeScheduleRepository implements ScheduleRepository
         return $this->fakeSchedules;
     }
 
-    public function save(Schedule $schedule) {}
+    public function save(Schedule $schedule)
+    {
+        return $schedule->getId() ?: 'fake-generated-id';
+    }
 }

--- a/src/main/php/Tapalava/Schedule/ScheduleRepository.php
+++ b/src/main/php/Tapalava/Schedule/ScheduleRepository.php
@@ -33,7 +33,7 @@ interface ScheduleRepository
      * Save a Schedule into persistence.
      *
      * @param Schedule $schedule The full Schedule object to be persisted.
-     * @return void
+     * @return string The ID of the schedule that was created or saved.
      */
     public function save(Schedule $schedule);
 }

--- a/src/main/php/Tapalava/ScheduleBundle/Resources/config/services.yml
+++ b/src/main/php/Tapalava/ScheduleBundle/Resources/config/services.yml
@@ -5,8 +5,14 @@ services:
             - '@m6web_cassandra.client.schedule'
             - '@schedule.date_transformer'
 
+    schedule.form_transformer:
+        class: Tapalava\Schedule\ScheduleFormTransformer
+
     schedule.date_transformer:
         class: Tapalava\Schedule\DateCollectionTransformer
+
+    http.request_parser:
+        class: Tapalava\Http\RequestParser
 
     event.repository:
         class: Tapalava\Event\FakeEventRepository

--- a/src/main/php/Tapalava/ScheduleBundle/Resources/views/Schedule/create.html.twig
+++ b/src/main/php/Tapalava/ScheduleBundle/Resources/views/Schedule/create.html.twig
@@ -8,20 +8,20 @@
                 <fieldset>
                     <h2>About Your Event</h2>
                     <label for="name">Name</label>
-                    <input name="name" id="name" type="text" placeholder="PizzaFest 2042" />
+                    <input name="schedule[name]" id="name" type="text" placeholder="PizzaFest 2042" />
 
                     <label for="startRange">Start Day</label>
-                    <input name="startRange" id="startRange" type="date">
+                    <input name="schedule[startDate]" id="startRange" type="date">
 
-                    <label for="startRange">End Day</label>
-                    <input name="endRange" id="endRange" type="date">
+                    <label for="endRange">End Day</label>
+                    <input name="schedule[endDate]" id="endRange" type="date">
 
                     <label for="location">Location</label>
-                    <input name="location" id="location" type="text" placeholder="Minneapolis, MN">
+                    <input name="schedule[location]" id="location" type="text" placeholder="Minneapolis, MN">
 
                     <label for="description">Description</label>
                     <textarea
-                        name="description"
+                        name="schedule[description]"
                         id="description"
                         placeholder="A place to gather and eat all the pizza."
                     ></textarea>
@@ -29,10 +29,10 @@
                 <fieldset>
                     <h2>Extra information</h2>
                     <label for="banner">Banner</label>
-                    <input name="banner" id="banner" type="text" placeholder="http://example.com/wow.jpg">
+                    <input name="schedule[banner]" id="banner" type="text" placeholder="http://example.com/wow.jpg">
 
                     <label for="tags">Tags</label>
-                    <input name="tags" id="tags" type="text" placeholder="Pizza, Fun">
+                    <input name="schedule[tags]" id="tags" type="text" placeholder="Pizza, Fun">
                 </fieldset>
                 <button type="submit">Create</button>
             </form>

--- a/src/test/php/Tapalava/Http/HttpParserTest.php
+++ b/src/test/php/Tapalava/Http/HttpParserTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tapalava\Http;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class HttpParserTest extends TestCase
+{
+    /**
+     * Ensure that HTTP forms will be decoded into arrays properly.
+     *
+     * @test
+     */
+    public function testHttpForm()
+    {
+        $parser = new RequestParser();
+        $request = new Request();
+        $request->setRequestFormat('html');
+        $request->request->set('test', ['foo' => 'bar', 'baz' => 'qux']);
+
+        $result = $parser->getEntityFromPost($request, 'test');
+
+        $this->assertEquals('bar', $result['foo']);
+        $this->assertEquals('qux', $result['baz']);
+    }
+
+    /**
+     * Parser should throw an HTTP exception if the key is missing/doesn't match.
+     *
+     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     * @test
+     */
+    public function testHttpFormMissingEntity()
+    {
+        $parser = new RequestParser();
+        $request = new Request();
+        $request->setRequestFormat('html');
+        $request->request->set('missing', ['foo' => 'bar', 'baz' => 'qux']);
+
+        $parser->getEntityFromPost($request, 'test');
+    }
+
+    /**
+     * Ensure that JSON Content is deserialized into a proper array.
+     *
+     * @test
+     */
+    public function testJsonContent()
+    {
+        $parser = new RequestParser();
+        $content = '{"test": { "foo": "bar", "baz": "qux" }}';
+        $request = new Request([], [], [], [], [], [], $content);
+        $request->setRequestFormat('json');
+
+        $result = $parser->getEntityFromPost($request, 'test');
+
+        $this->assertEquals('bar', $result['foo']);
+        $this->assertEquals('qux', $result['baz']);
+    }
+
+    /**
+     * Parser should throw an HTTP exception invalid JSON is provided
+     *
+     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     * @test
+     */
+    public function testJsonContentInvalid()
+    {
+        $parser = new RequestParser();
+        $content = 'This is not JSON!';
+        $request = new Request([], [], [], [], [], [], $content);
+        $request->setRequestFormat('json');
+
+        $parser->getEntityFromPost($request, 'test');
+    }
+
+    /**
+     * Parser should throw an HTTP exception if the key is missing/doesn't match.
+     *
+     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     * @test
+     */
+    public function testJsonContentMissingEntity()
+    {
+        $parser = new RequestParser();
+        $content = '{"missing": { "foo": "bar", "baz": "qux" }}';
+        $request = new Request([], [], [], [], [], [], $content);
+        $request->setRequestFormat('json');
+
+        $parser->getEntityFromPost($request, 'test');
+    }
+
+    /**
+     * Parser should throw an error if the request format doesn't match anything known.
+     *
+     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     * @test
+     */
+    public function testUnknownFormat()
+    {
+        $parser = new RequestParser();
+        $request = new Request();
+        $request->setRequestFormat('foo');
+
+        $parser->getEntityFromPost($request, 'test');
+    }
+}

--- a/src/test/php/Tapalava/ScheduleBundle/Controller/ScheduleControllerTest.php
+++ b/src/test/php/Tapalava/ScheduleBundle/Controller/ScheduleControllerTest.php
@@ -70,7 +70,7 @@ class ScheduleControllerTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $client->request('POST', '/schedule/create.html');
+        $client->request('POST', '/schedule/create.json', [], [], [], '{"schedule": {}}');
         $this->assertEquals(302, $client->getResponse()->getStatusCode());
     }
 }


### PR DESCRIPTION
Connects the schedule submit action to create a cassandra entity when
it receives a request.
Creates a generic HTTP Request parser for pulling data out of a HTTP form
or a JSON entity that was posted.