### PR TITLE
Add Event Creation form

### DIFF
--- a/src/main/php/Tapalava/Event/Event.php
+++ b/src/main/php/Tapalava/Event/Event.php
@@ -42,7 +42,7 @@ class Event
     private $description;
 
     /** @var null|string A background banner image to use as a backdrop. */
-    private $scrim;
+    private $banner;
 
     /**
      * @param null $id UUID for this object.
@@ -55,7 +55,7 @@ class Event
      * @param null $room What room the event is held in.
      * @param array|null $hosts Who is speaking or facilitating at the event.
      * @param null $description A user-defined description of the event.
-     * @param null $scrim A background banner image to use as a backdrop.
+     * @param null $banner A background banner image to use as a backdrop.
      */
     public function __construct(
         $id = null,
@@ -68,7 +68,7 @@ class Event
         $room = null,
         array $hosts = null,
         $description = null,
-        $scrim = null
+        $banner = null
     ) {
         $this->id = $id;
         $this->scheduleId = $scheduleId;
@@ -80,7 +80,7 @@ class Event
         $this->room = $room;
         $this->hosts = $hosts ?: [];
         $this->description = $description;
-        $this->scrim = $scrim;
+        $this->banner = $banner;
     }
 
     /**
@@ -168,8 +168,8 @@ class Event
     /**
      * @return null|string A background banner image to use as a backdrop.
      */
-    public function getScrim()
+    public function getBanner()
     {
-        return $this->scrim;
+        return $this->banner;
     }
 }

--- a/src/main/php/Tapalava/Event/EventFormTransformer.php
+++ b/src/main/php/Tapalava/Event/EventFormTransformer.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tapalava\Event;
+
+use DateInterval;
+use DatePeriod;
+use DateTime;
+
+/**
+ * Transforms Schedule models to and from view-form appropriate array data.
+ *
+ * @author Maxwell Vandervelde <Max@MaxVandervelde.com>
+ */
+class EventFormTransformer
+{
+    /**
+     * Change view array data into a Schedule model.
+     *
+     * @param array $viewData The array data from a view form.
+     * @return Event The equivalent model object matching the given array.
+     */
+    public function fromView(array $viewData, $scheduleId = null): Event
+    {
+        $id = $viewData['id'] ?? null;
+
+        $name = $viewData['name'] ?? null;
+        $description = $viewData['description'] ?? null;
+        $banner = $viewData['banner'] ?? null;
+        $category = $viewData['category'] ?? null;
+        $room = $viewData['room'] ?? null;
+
+        $start = isset($viewData['start']) ? new DateTime($viewData['start']) : null;
+        $end = isset($viewData['end']) ? new DateTime($viewData['end']) : null;
+
+        $rawTags = $viewData['tags'] ?? null;
+        $tags = empty($rawTags) ? [] : explode(',', $rawTags);
+        array_walk($tags, [$this, 'cleanTag']);
+
+        $rawHosts = $viewData['hosts'] ?? null;
+        $hosts = empty($rawHosts) ? [] : explode(',', $rawHosts);
+        array_walk($hosts, [$this, 'cleanTag']);
+
+
+        return new Event($id, $scheduleId, $name, $start, $end, $category, $tags, $room, $hosts, $description, $banner);
+    }
+
+    /**
+     * Change a Schedule model into an array of view data.
+     *
+     * @param Event $model Model data to be changed into a view-form data.
+     * @return array The equivalent form view-data matching the model.
+     */
+    public function toView(Event $model): array
+    {
+        return [
+            'id' => $model->getId(),
+            'scheduleId' => $model->getScheduleId(),
+            'name' => $model->getName(),
+            'start' => $model->getStart() == null ? null : $model->getStart()->format(DateTime::RFC3339),
+            'end' => $model->getEnd() == null ? null : $model->getEnd()->format(DateTime::RFC3339),
+            'category' => $model->getCategory(),
+            'tags' => null == $model->getTags() ? null : implode(',', $model->getTags()),
+            'room' => $model->getRoom(),
+            'hosts' => null == $model->getHosts() ? null : implode(',', $model->getHosts()),
+            'description' => $model->getDescription(),
+            'banner' => $model->getBanner(),
+        ];
+    }
+
+    /**
+     * Normalize any insignificant formatting discrepancies in tags.
+     *
+     * @param string $tag the tag to be cleaned.
+     * @return string The clean version of the tag.
+     */
+    protected function cleanTag($tag)
+    {
+        return trim($tag);
+    }
+}

--- a/src/main/php/Tapalava/Event/EventRepository.php
+++ b/src/main/php/Tapalava/Event/EventRepository.php
@@ -16,7 +16,7 @@ interface EventRepository
      * @return Event The Event matching the ID provided.
      * @throws EventNotFoundException If the event ID doesn't exist.
      */
-    public function find($id) : Event;
+    public function find($id): Event;
 
     /**
      * Find all events associated with a specified schedule.
@@ -25,24 +25,13 @@ interface EventRepository
      * @return array The events associated with the provided schedule ID. Empty
      *               if none found, never null.
      */
-    public function findAll($scheduleId) : array;
+    public function findAll($scheduleId): array;
 
     /**
      * Persist a new Event to application storage.
      *
-     * @param Event $event the new event to create in the data storage.
-     * @return Event The persisted event with updated information that may have
-     *               been changed by the data storage, such as an
-     *               auto-generated ID.
+     * @param Event $event the new event to update in the data storage.
+     * @return Event The ID of the event saved (this will be generated if new)
      */
-    public function create(Event $event) : Event;
-
-    /**
-     * Persist updated information to an existing Event in application storage.
-     *
-     * @param Event $event the event to update in the data storage.
-     * @return Event The persisted event with updated information that may have
-     *               been changed by the data storage, such as a timestamp.
-     */
-    public function update(Event $event) : Event;
+    public function save(Event $event);
 }

--- a/src/main/php/Tapalava/Event/FakeEventRepository.php
+++ b/src/main/php/Tapalava/Event/FakeEventRepository.php
@@ -22,7 +22,7 @@ class FakeEventRepository implements EventRepository
         $this->fakeEvents = [$full, $minimal];
     }
 
-    public function find($id) : Event
+    public function find($id): Event
     {
         switch ($id) {
             case 'fake-event-id-001':
@@ -34,7 +34,7 @@ class FakeEventRepository implements EventRepository
         }
     }
 
-    public function findAll($scheduleId) : array
+    public function findAll($scheduleId): array
     {
         if ('fake-id-001' === $scheduleId) {
             return $this->fakeEvents;
@@ -42,14 +42,8 @@ class FakeEventRepository implements EventRepository
 
         throw new ScheduleNotFoundException($scheduleId);
     }
-
-    public function create(Event $event) : Event
+    public function save(Event $event)
     {
-        return $event;
-    }
-
-    public function update(Event $event) : Event
-    {
-        return $event;
+        return $event->getId() ?? 'fake-generated-id';
     }
 }

--- a/src/main/php/Tapalava/ScheduleBundle/Controller/EventController.php
+++ b/src/main/php/Tapalava/ScheduleBundle/Controller/EventController.php
@@ -3,14 +3,16 @@
 namespace Tapalava\ScheduleBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use JMS\SecurityExtraBundle\Annotation\Secure;
 use JMS\DiExtraBundle\Annotation\Inject;
 use JMS\DiExtraBundle\Annotation\InjectParams;
-use Tapalava\Event\EventNotFoundException;
+use Tapalava\Event\EventFormTransformer;
 use Tapalava\Event\EventRepository;
+use Tapalava\Http\RequestParser;
 use Tapalava\Schedule\ScheduleNotFoundException;
 use Tapalava\Schedule\ScheduleRepository;
 
@@ -20,25 +22,38 @@ use Tapalava\Schedule\ScheduleRepository;
  * @Route("/schedule/{schedule}")
  * @author Maxwell Vandervelde <Max@MaxVandervelde.com>
  */
-class EventController
+class EventController extends Controller
 {
-    /**
-     * @var ScheduleRepository For accessing schedule data.
-     */
+    /** @var ScheduleRepository For accessing schedule data. */
     private $scheduleRepository;
 
+    /** @var EventRepository Service for looking up data about a schedule's events. */
     private $eventRepository;
+
+    /** @var RequestParser For transforming form posts into a consistent format. */
+    private $requestParser;
+
+    /** @var EventFormTransformer For transforming data to and from a view format. */
+    private $formTransformer;
 
     /**
      * @InjectParams({
      *     "scheduleRepository" = @Inject("schedule.repository"),
-     *     "eventRepository" = @Inject("event.repository")
+     *     "eventRepository" = @Inject("event.repository"),
+     *     "requestParser" = @Inject("http.request_parser"),
+     *     "formTransformer" = @Inject("event.form_transformer")
      * })
      */
-    public function __construct(ScheduleRepository $scheduleRepository, EventRepository $eventRepository)
-    {
+    public function __construct(
+        ScheduleRepository $scheduleRepository,
+        EventRepository $eventRepository,
+        RequestParser $requestParser,
+        EventFormTransformer $formTransformer
+    ) {
         $this->scheduleRepository = $scheduleRepository;
         $this->eventRepository = $eventRepository;
+        $this->requestParser = $requestParser;
+        $this->formTransformer = $formTransformer;
     }
 
     /**
@@ -57,5 +72,39 @@ class EventController
         } catch (ScheduleNotFoundException $e) {
             throw new NotFoundHttpException("Schedule was not found");
         }
+    }
+
+    /**
+     * Form page for creating a new event for a schedule.
+     *
+     * @Route("/create", methods={"GET"}, name="event-create")
+     * @Template
+     */
+    public function createAction($schedule)
+    {
+        try {
+            return [
+                'schedule' => $this->scheduleRepository->find($schedule),
+            ];
+        } catch (ScheduleNotFoundException $e) {
+            throw new NotFoundHttpException("Schedule was not found");
+        }
+    }
+
+    /**
+     * Form page for creating a new event for a schedule.
+     *
+     * @Route("/create.{_format}", methods={"POST"}, name="event-create-submit", defaults={"_format" = "html"})
+     */
+    public function createSubmitAction($_format, Request $request, $schedule)
+    {
+        $data = $this->requestParser->getEntityFromPost($request, 'event');
+        $event = $this->formTransformer->fromView($data, $schedule);
+        $id = $this->eventRepository->save($event);
+
+        return $this->redirectToRoute(
+            'events-read',
+            ['schedule' => $schedule, '_format' => $_format]
+        );
     }
 }

--- a/src/main/php/Tapalava/ScheduleBundle/Resources/config/services.yml
+++ b/src/main/php/Tapalava/ScheduleBundle/Resources/config/services.yml
@@ -17,6 +17,9 @@ services:
     event.repository:
         class: Tapalava\Event\FakeEventRepository
 
+    event.form_transformer:
+        class: Tapalava\Event\EventFormTransformer
+
     format_content_type:
         class: Tapalava\ScheduleBundle\Response\FormatContentType
         tags:

--- a/src/main/php/Tapalava/ScheduleBundle/Resources/views/Event/create.html.twig
+++ b/src/main/php/Tapalava/ScheduleBundle/Resources/views/Event/create.html.twig
@@ -1,0 +1,47 @@
+{% extends '::default.html.twig' %}
+
+{% block content %}
+    <div class="container">
+        <section>
+            <h1>New Event for {{ schedule.name }}</h1>
+            <form method="post" action="{{ url('event-create-submit', {"schedule": schedule.id}) }}">
+                <fieldset>
+                    <h2>About Your Event</h2>
+                    <label for="name">Event Name</label>
+                    <input name="event[name]" id="name" type="text" placeholder="Pizza eating 101" />
+
+                    <label for="startRange">Start Day</label>
+                    <input name="event[startDate]" id="startRange" type="datetime-local">
+
+                    <label for="endRange">End Day</label>
+                    <input name="event[endDate]" id="endRange" type="datetime-local">
+
+                    <label for="category">Category</label>
+                    <input name="event[category]" id="category" type="text" placeholder="Tutorials">
+
+                    <label for="category">Hosts</label>
+                    <input name="event[hosts]" id="hosts" type="text" placeholder="John Doe, Jane Doe">
+
+                    <label for="room">Room / Location</label>
+                    <input name="event[room]" id="room" type="text" placeholder="Main Stage">
+
+                    <label for="description">Description</label>
+                    <textarea
+                        name="event[description]"
+                        id="description"
+                        placeholder="Learn how to eat pizza the right way."
+                    ></textarea>
+                </fieldset>
+                <fieldset>
+                    <h2>Extra information</h2>
+                    <label for="banner">Banner</label>
+                    <input name="event[banner]" id="banner" type="text" placeholder="http://example.com/wow.jpg">
+
+                    <label for="tags">Tags</label>
+                    <input name="event[tags]" id="tags" type="text" placeholder="Pizza, Fun">
+                </fieldset>
+                <button type="submit">Create</button>
+            </form>
+        </section>
+    </div>
+{% endblock %}

--- a/src/test/php/Tapalava/Event/EventFormTransformerTest.php
+++ b/src/test/php/Tapalava/Event/EventFormTransformerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tapalava\Event;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use DateTime;
+
+class EventFormTransformerTest extends TestCase
+{
+    /**
+     * Ensure that all properties are transformed to the model form correctly.
+     *
+     * @dataProvider validTransformations
+     * @test
+     */
+    public function validFromView($viewData, Event $expectedObject, $scheduleId)
+    {
+        $test = new EventFormTransformer();
+
+        $result = $test->fromView($viewData, $scheduleId);
+
+        $this->assertEquals($expectedObject->getId(), $result->getId());
+        $this->assertEquals($scheduleId, $result->getScheduleId());
+        $this->assertEquals($expectedObject->getName(), $result->getName());
+        $this->assertEquals($expectedObject->getStart(), $result->getStart());
+        $this->assertEquals($expectedObject->getEnd(), $result->getEnd());
+        $this->assertEquals($expectedObject->getCategory(), $result->getCategory());
+        $this->assertEquals($expectedObject->getTags(), $result->getTags());
+        $this->assertEquals($expectedObject->getRoom(), $result->getRoom());
+        $this->assertEquals($expectedObject->getHosts(), $result->getHosts());
+        $this->assertEquals($expectedObject->getDescription(), $result->getDescription());
+        $this->assertEquals($expectedObject->getBanner(), $result->getBanner());
+    }
+
+    /**
+     * Ensure that all properties are transformed to view data correctly.
+     *
+     * @dataProvider validTransformations
+     * @test
+     */
+    public function validFromModel($expectedViewData, Event $model)
+    {
+        $test = new EventFormTransformer();
+
+        $result = $test->toView($model);
+
+        $this->assertEquals($expectedViewData['id'] ?? null, $result['id'] ?? null);
+        $this->assertEquals($expectedViewData['scheduleId'] ?? null, $result['scheduleId'] ?? null);
+        $this->assertEquals($expectedViewData['name'] ?? null, $result['name'] ?? null);
+        $this->assertEquals($expectedViewData['start'] ?? null, $result['start'] ?? null);
+        $this->assertEquals($expectedViewData['end'] ?? null, $result['end'] ?? null);
+        $this->assertEquals($expectedViewData['category'] ?? null, $result['category'] ?? null);
+        $this->assertEquals($expectedViewData['tags'] ?? null, $result['tags'] ?? null);
+        $this->assertEquals($expectedViewData['room'] ?? null, $result['room'] ?? null);
+        $this->assertEquals($expectedViewData['hosts'] ?? null, $result['hosts'] ?? null);
+        $this->assertEquals($expectedViewData['description'] ?? null, $result['description'] ?? null);
+        $this->assertEquals($expectedViewData['banner'] ?? null, $result['banner'] ?? null);
+    }
+
+    /**
+     * Ensure that properties can be transformed back and forth without loss.
+     *
+     * @dataProvider validTransformations
+     * @test
+     */
+    public function bijectivity($viewData, Event $model)
+    {
+        $test = new EventFormTransformer();
+
+        $newModel = $test->fromView($viewData, $viewData['scheduleId'] ?? null);
+        $newView = $test->toView($newModel);
+
+        $this->assertEquals($model->getId(), $newModel->getId());
+        $this->assertEquals($model->getScheduleId(), $newModel->getScheduleId());
+        $this->assertEquals($model->getName(), $newModel->getName());
+        $this->assertEquals($model->getStart(), $newModel->getStart());
+        $this->assertEquals($model->getEnd(), $newModel->getEnd());
+        $this->assertEquals($model->getCategory(), $newModel->getCategory());
+        $this->assertEquals($model->getTags(), $newModel->getTags());
+        $this->assertEquals($model->getRoom(), $newModel->getRoom());
+        $this->assertEquals($model->getHosts(), $newModel->getHosts());
+        $this->assertEquals($model->getDescription(), $newModel->getDescription());
+        $this->assertEquals($model->getBanner(), $newModel->getBanner());
+
+        $this->assertEquals($viewData['id'] ?? null, $newView['id'] ?? null);
+        $this->assertEquals($viewData['scheduleId'] ?? null, $newView['scheduleId'] ?? null);
+        $this->assertEquals($viewData['name'] ?? null, $newView['name'] ?? null);
+        $this->assertEquals($viewData['start'] ?? null, $newView['start'] ?? null);
+        $this->assertEquals($viewData['end'] ?? null, $newView['end'] ?? null);
+        $this->assertEquals($viewData['category'] ?? null, $newView['category'] ?? null);
+        $this->assertEquals($viewData['tags'] ?? null, $newView['tags'] ?? null);
+        $this->assertEquals($viewData['room'] ?? null, $newView['room'] ?? null);
+        $this->assertEquals($viewData['hosts'] ?? null, $newView['hosts'] ?? null);
+        $this->assertEquals($viewData['description'] ?? null, $newView['description'] ?? null);
+        $this->assertEquals($viewData['banner'] ?? null, $newView['banner'] ?? null);
+    }
+
+    public static function validTransformations()
+    {
+        return [
+            [
+                [
+                    'id' => 'fake-event-001',
+                    'scheduleId' => 'fake-schedule-id-001',
+                    'name' => 'Fake Event',
+                    'start' => '2016-12-15T06:00:00+05:00',
+                    'end' => '2016-12-15T08:00:00+05:00',
+                    'category' => 'Fake Category',
+                    'tags' => 'a,b,c',
+                    'room' => 'Fake Room',
+                    'hosts' => 'john,jane',
+                    'description' => 'Fake Description',
+                    'banner' => 'http://nope.city/.gif',
+                ],
+                new Event(
+                    'fake-event-001',
+                    'fake-schedule-id-001',
+                    'Fake Event',
+                    new DateTime('2016-12-15T06:00:00+05:00'),
+                    new DateTime('2016-12-15T08:00:00+05:00'),
+                    'Fake Category',
+                    ['a', 'b', 'c'],
+                    'Fake Room',
+                    ['john', 'jane'],
+                    'Fake Description',
+                    'http://nope.city/.gif'
+                ),
+                'fake-schedule-id-lookup',
+            ],
+            [
+                [],
+                new Event(),
+                null,
+            ],
+        ];
+    }
+}

--- a/src/test/php/Tapalava/Event/EventTest.php
+++ b/src/test/php/Tapalava/Event/EventTest.php
@@ -42,7 +42,7 @@ class EventTest extends TestCase
         $this->assertEquals('tag-a', $test->getTags()[0]);
         $this->assertEquals('tag-b', $test->getTags()[1]);
         $this->assertEquals('fake description', $test->getDescription());
-        $this->assertEquals('fake scrim uri', $test->getScrim());
+        $this->assertEquals('fake scrim uri', $test->getBanner());
     }
 
     /**
@@ -61,7 +61,7 @@ class EventTest extends TestCase
         $this->assertNull($test->getEnd());
         $this->assertNull($test->getCategory());
         $this->assertNull($test->getDescription());
-        $this->assertNull($test->getScrim());
+        $this->assertNull($test->getBanner());
         $this->assertNull($test->getRoom());
 
         $this->assertNotNull($test->getTags());

--- a/src/test/php/Tapalava/Event/FakeEventRepositoryTest.php
+++ b/src/test/php/Tapalava/Event/FakeEventRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Tapalava\Event;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\Validator\Constraints\DateTime;
 
 class FakeEventRepositoryTest extends TestCase
 {
@@ -45,6 +46,22 @@ class FakeEventRepositoryTest extends TestCase
         $test = $repository->findAll('fake-id-001');
 
         $this->assertNotEmpty($test);
+    }
+
+    /**
+     * Entities can be saved without error
+     *
+     * @test
+     */
+    public function save()
+    {
+        $repository = new FakeEventRepository();
+
+        $test = $repository->save(new Event('fake-id', 'fake-schedule-id', 'fake name', new DateTime(), new DateTime(), 'fake category', ['a', 'b'], 'fake room', ['john'], 'fake description', 'fake banner'));
+        $testEmpty = $repository->save(new Event());
+
+        $this->assertNotEmpty($test);
+        $this->assertNotEmpty($testEmpty);
     }
 
     /**

--- a/src/test/php/Tapalava/Schedule/ScheduleFormTransformerTest.php
+++ b/src/test/php/Tapalava/Schedule/ScheduleFormTransformerTest.php
@@ -62,7 +62,7 @@ class ScheduleFormTransformerTest extends TestCase
         $test = new ScheduleFormTransformer();
 
         $newModel = $test->fromView($viewData);
-        $newView = $test->toView($model);
+        $newView = $test->toView($newModel);
 
         $this->assertEquals($model->getId(), $newModel->getId());
         $this->assertEquals($model->getName(), $newModel->getName());

--- a/src/test/php/Tapalava/ScheduleBundle/Controller/EventControllerTest.php
+++ b/src/test/php/Tapalava/ScheduleBundle/Controller/EventControllerTest.php
@@ -19,7 +19,7 @@ class EventControllerTest extends WebTestCase
         $client->request('GET', '/schedule/fake-id-001/events');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
 
-        $client->request('GET', '/schedule/fake-id-001/events');
+        $client->request('GET', '/schedule/fake-id-001/events.json');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
 
@@ -33,7 +33,49 @@ class EventControllerTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $client->request('GET', '/schedule/missing-id');
+        $client->request('GET', '/schedule/missing-id/events');
         $this->assertEquals(404, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * Form page for creating a new event should load successfully.
+     *
+     * @test
+     * @group functional
+     */
+    public function createEventForm()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/schedule/fake-id-001/create');
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * Form page should 404 if the schedule ID isn't found.
+     *
+     * @test
+     * @group functional
+     */
+    public function createEventFormMissing()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/schedule/missing-id/create');
+        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * Form page for creating a new event should load successfully.
+     *
+     * @test
+     * @group functional
+     */
+    public function createEventFormSubmit()
+    {
+        $client = static::createClient();
+
+        $client->request('POST', '/schedule/fake-id-001/create.json', [], [], [], '{"event": {}}');
+        $this->assertEquals(302, $client->getResponse()->getStatusCode());
     }
 }


### PR DESCRIPTION
Creates a basic form for creating new evets. Data is not hooked up with
this change, it is still using the fake endpoints for now.
Changed the scrim property to be named 'banner' for consistency.
Adds endpoint for form to submit to.