### PR TITLE
Fix empty column set exception.

### DIFF
--- a/src/main/php/Tapalava/Cassandra/Row.php
+++ b/src/main/php/Tapalava/Cassandra/Row.php
@@ -46,6 +46,7 @@ class Row implements ArrayAccess
      * </p>
      * @return mixed Can return all value types.
      * @since 5.0.0
+     * @throws ColumnNotFoundException
      */
     public function offsetGet($offset)
     {

--- a/src/main/php/Tapalava/Event/CassandraEventRepository.php
+++ b/src/main/php/Tapalava/Event/CassandraEventRepository.php
@@ -3,6 +3,7 @@
 namespace Tapalava\Event;
 
 use Cassandra\ExecutionOptions;
+use Cassandra\Rows;
 use Cassandra\SimpleStatement;
 use Cassandra\Type;
 use Cassandra\Uuid;
@@ -41,13 +42,14 @@ class CassandraEventRepository implements EventRepository
         $statement = new SimpleStatement('SELECT * FROM event WHERE schedule_id=? AND id=?');
         $options = new ExecutionOptions(['arguments' => ['schedule_id' => $scheduleId, 'id' => $id]]);
 
+        /** @var Rows $results */
         $results = $this->client->execute($statement, $options);
 
-        if (count($results) == 0) {
+        if ($results->count() === 0) {
             throw new ScheduleNotFoundException($id);
         }
 
-        return $this->fromRow(new Row($results[0]));
+        return $this->fromRow(new Row($results->first()));
     }
 
     /**

--- a/src/main/php/Tapalava/Schedule/CassandraScheduleRepository.php
+++ b/src/main/php/Tapalava/Schedule/CassandraScheduleRepository.php
@@ -2,6 +2,7 @@
 
 namespace Tapalava\Schedule;
 use Cassandra\ExecutionOptions;
+use Cassandra\Rows;
 use Cassandra\SimpleStatement;
 use Cassandra\Type;
 use Cassandra\Uuid;
@@ -44,13 +45,14 @@ class CassandraScheduleRepository implements ScheduleRepository
         $statement = new SimpleStatement('SELECT * FROM schedule WHERE id=?');
         $options = new ExecutionOptions(['arguments' => ['id' => $id]]);
 
+        /** @var Rows $results */
         $results = $this->client->execute($statement, $options);
 
-        if (count($results) == 0) {
+        if ($results->count() === 0) {
             throw new ScheduleNotFoundException($id);
         }
 
-        return $this->fromRow(new Row($results[0]));
+        return $this->fromRow(new Row($results->first()));
     }
 
     /**

--- a/src/test/php/Tapalava/Event/CassandraEventRepositoryTest.php
+++ b/src/test/php/Tapalava/Event/CassandraEventRepositoryTest.php
@@ -9,6 +9,7 @@ use Cassandra\Statement;
 use DateTime;
 use M6Web\Bundle\CassandraBundle\Cassandra\Client;
 use PHPUnit_Framework_TestCase as TestCase;
+use Doctrine\Common\Collections\ArrayCollection as FakeCassandraRows;
 
 class CassandraEventRepositoryTest extends TestCase
 {
@@ -31,7 +32,7 @@ class CassandraEventRepositoryTest extends TestCase
                 $hosts->add('jane');
                 $hosts->add('john');
 
-                return [
+                return new FakeCassandraRows([
                     [
                         'id' => 'fake-id-001',
                         'schedule_id' => 'fake-schedule-id',
@@ -45,7 +46,7 @@ class CassandraEventRepositoryTest extends TestCase
                         'description' => 'fake description',
                         'banner' => 'http://nope.city/.gif',
                     ]
-                ];
+                ]);
             }
         };
         $repository = new CassandraEventRepository($stubClient);
@@ -81,7 +82,7 @@ class CassandraEventRepositoryTest extends TestCase
         $stubClient = new class extends Client {
             public function __construct() {}
             public function execute(Statement $statement, ExecutionOptions $options = null) {
-                return [];
+                return new FakeCassandraRows([]);
             }
         };
 
@@ -109,7 +110,7 @@ class CassandraEventRepositoryTest extends TestCase
                 $hosts->add('jane');
                 $hosts->add('john');
 
-                return [
+                return new FakeCassandraRows([
                     [
                         'id' => 'fake-id-001',
                         'schedule_id' => 'fake-schedule-id',
@@ -127,7 +128,7 @@ class CassandraEventRepositoryTest extends TestCase
                         'id' => 'fake-id-002',
                         'schedule_id' => 'fake-schedule-id',
                     ]
-                ];
+                ]);
             }
         };
         $repository = new CassandraEventRepository($stubClient);
@@ -169,7 +170,7 @@ class CassandraEventRepositoryTest extends TestCase
             public function __construct() {}
 
             public function execute(Statement $statement, ExecutionOptions $options = null) {
-                return [];
+                return new FakeCassandraRows([]);
             }
         };
         $repository = new CassandraEventRepository($stubClient);
@@ -213,7 +214,7 @@ class CassandraEventRepositoryTest extends TestCase
                 $this->test->assertEquals('This is a fake event description', $arguments['description']);
                 $this->test->assertEquals('http://google.com/google.png', $arguments['banner']);
 
-                return [];
+                return new FakeCassandraRows([]);
             }
         };
         $repository = new CassandraEventRepository($spyClient);
@@ -266,7 +267,7 @@ class CassandraEventRepositoryTest extends TestCase
                 $this->test->assertNull($arguments['description']);
                 $this->test->assertNull($arguments['banner']);
 
-                return [];
+                return new FakeCassandraRows([]);
             }
         };
         $repository = new CassandraEventRepository($spyClient);

--- a/src/test/php/Tapalava/Schedule/CassandraScheduleRepositoryTest.php
+++ b/src/test/php/Tapalava/Schedule/CassandraScheduleRepositoryTest.php
@@ -9,6 +9,7 @@ use Cassandra\Statement;
 use DateTime;
 use M6Web\Bundle\CassandraBundle\Cassandra\Client;
 use PHPUnit_Framework_TestCase as TestCase;
+use Doctrine\Common\Collections\ArrayCollection as FakeCassandraRows;
 
 class CassandraScheduleRepositoryTest extends TestCase
 {
@@ -31,7 +32,7 @@ class CassandraScheduleRepositoryTest extends TestCase
                 $dates->add('2016-04-01');
                 $dates->add('2016-04-02');
 
-                return [
+                return new FakeCassandraRows([
                     [
                         'id' => 'fake-id-001',
                         'name' => 'fake-name',
@@ -41,7 +42,7 @@ class CassandraScheduleRepositoryTest extends TestCase
                         'location' => 'Springfield',
                         'tags' => $tags,
                     ]
-                ];
+                ]);
             }
         };
         $stubTransformer = new class extends DateCollectionTransformer {
@@ -79,7 +80,7 @@ class CassandraScheduleRepositoryTest extends TestCase
         $stubClient = new class extends Client {
             public function __construct() {}
             public function execute(Statement $statement, ExecutionOptions $options = null) {
-                return [];
+                return new FakeCassandraRows([]);
             }
         };
         $stubTransformer = new class extends DateCollectionTransformer {
@@ -110,7 +111,7 @@ class CassandraScheduleRepositoryTest extends TestCase
                 $dates->add('2016-04-01');
                 $dates->add('2016-04-02');
 
-                return [
+                return new FakeCassandraRows([
                     [
                         'id' => 'fake-id-001',
                         'name' => 'fake-name',
@@ -123,7 +124,7 @@ class CassandraScheduleRepositoryTest extends TestCase
                     [
                         'id' => 'fake-id-002',
                     ],
-                ];
+                ]);
             }
         };
         $stubTransformer = new class extends DateCollectionTransformer {
@@ -166,7 +167,7 @@ class CassandraScheduleRepositoryTest extends TestCase
             public function __construct() {}
 
             public function execute(Statement $statement, ExecutionOptions $options = null) {
-                return [];
+                return new FakeCassandraRows([]);
             }
         };
         $stubTransformer = new class extends DateCollectionTransformer {
@@ -212,7 +213,7 @@ class CassandraScheduleRepositoryTest extends TestCase
                 $this->test->assertEquals('a'  , $arguments['tags']->get(0));
                 $this->test->assertEquals('b'  , $arguments['tags']->get(1));
 
-                return [];
+                return new FakeCassandraRows([]);
             }
         };
         $stubTransformer = new class extends DateCollectionTransformer {
@@ -272,7 +273,7 @@ class CassandraScheduleRepositoryTest extends TestCase
                 $this->test->assertInstanceOf(Collection::class, $arguments['tags']);
                 $this->test->assertEquals(0 , $arguments['tags']->count());
 
-                return [];
+                return new FakeCassandraRows([]);
             }
         };
         $stubTransformer = new class extends DateCollectionTransformer {


### PR DESCRIPTION
Repository was using the `count()` method instead of the `Rows#size()`
method which would cause it to return an empty rowset and get a `ColumnNotFound`
exception instead of the proper `ScheduleNotFoundException`